### PR TITLE
Support ScalarDB driver

### DIFF
--- a/server/bundles/io.cloudbeaver.resources.drivers.base/plugin.xml
+++ b/server/bundles/io.cloudbeaver.resources.drivers.base/plugin.xml
@@ -17,6 +17,7 @@
         <resource name="drivers/sqlite/xerial"/>
         <resource name="drivers/mssql/new"/>
         <resource name="drivers/trino"/>
+        <resource name="drivers/scalardb"/>
     </extension>
 
     <!-- Bundles  -->
@@ -36,6 +37,7 @@
         <bundle id="drivers.sqlite.xerial" label="SQLite drivers"/>
         <bundle id="drivers.mssql.new" label="SQL Server drivers"/>
         <bundle id="drivers.trino" label="Trino drivers"/>
+        <bundle id="drivers.scalardb" label="ScalarDB drivers"/>
     </extension>
 
     <!-- Enabled drivers -->
@@ -55,6 +57,7 @@
         <driver id="sqlite:sqlite_jdbc"/>
         <driver id="sqlserver:microsoft"/>
         <driver id="generic:trino_jdbc"/>
+        <driver id="generic:scalardb"/>
     </extension>
 
 

--- a/server/drivers/pom.xml
+++ b/server/drivers/pom.xml
@@ -26,6 +26,7 @@
         <module>sqlite</module>
         <module>sqlserver</module>
         <module>trino</module>
+        <module>scalardb</module>
     </modules>
 
     <build>

--- a/server/drivers/scalardb/pom.xml
+++ b/server/drivers/scalardb/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>drivers.scalardb</artifactId>
+    <version>1.0.0</version>
+    <parent>
+        <groupId>io.cloudbeaver</groupId>
+        <artifactId>drivers</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <properties>
+        <deps.output.dir>scalardb</deps.output.dir>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>oss.sonatype.org</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.scalar-labs</groupId>
+            <artifactId>scalardb-sql-jdbc</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.scalar-labs</groupId>
+            <artifactId>scalardb-sql-direct-mode</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
## Description

This PR adds settings to include the ScalarDB driver. CloudBeaver depends on DBeaver, so you need the corresponding version of DBeaver, which includes https://github.com/scalar-labs/dbeaver/pull/1.

## Related issues and/or PRs

https://github.com/scalar-labs/dbeaver/pull/1

## Changes made

- Add settings for the ScalarDB driver

## Additional notes (optional)

You need additional settings to get ScalarDB SQL packages when building this. Follow the guide of the Maven case in https://github.com/scalar-labs/scalardb-sql.

We would like this PR to be included in the upstream in the future, but we will maintain it in our branch for a while until it's ready.